### PR TITLE
Fix syntax error in CI report curl command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           if [ "${{ steps.pytest_step.outcome }}" != "success" ]; then
             STATUS="❌ Тесты не пройдены"
           fi
-          curl -X POST "'"$CI_ENDPOINT"'" \
+          curl -X POST "$CI_ENDPOINT" \
             -H "Content-Type: application/json" \
             -d '{
               "secret": "'"$SECRET"'",


### PR DESCRIPTION
Correct the syntax in the CI report curl command to ensure proper execution.