### PR TITLE
Refactor service check and fix CI variable interpolation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{
               "secret": "'"$SECRET"'",
-              "project": ${{ github.repository }},
+              "project": "'"${{ github.repository }}"'",
               "status": "'"$STATUS"'",
               "commit": "'"$(git rev-parse --short HEAD)"'",
               "author": "'"${{ github.actor }}"'",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{
               "secret": "'"$SECRET"'",
-              "project": ${{ github.repository }},
+              "project": "'"${{ github.repository }}"'",
               "status": "'"$STATUS"'",
               "commit": "'"$(git rev-parse --short HEAD)"'",
               "author": "'"${{ github.actor }}"'",

--- a/system_report.py
+++ b/system_report.py
@@ -26,7 +26,7 @@ def check_service(service_name):
     try:
         # Явно указываем путь к systemctl
         result = subprocess.run(
-            ["/usr/bin/systemctl", "is-active", service_name],
+            ["systemctl", "is-active", service_name],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,


### PR DESCRIPTION
Simplify the command path in the `check_service` function and correct the project variable interpolation in the CI report for deploy and test workflows.