### PR TITLE
Add Telegram command to retrieve last deploy report

### DIFF
--- a/CI_report.py
+++ b/CI_report.py
@@ -5,6 +5,14 @@ from fastapi import FastAPI, HTTPException, Request
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup
 
 
+# Глобальная переменная для хранения последнего деплоя
+_last_deploy_report = None
+
+
+def get_last_deploy_report():
+    return _last_deploy_report
+
+
 def create_bot_server(tg_token: str, chat_id: str, ci_secret: str) -> FastAPI:
     app = FastAPI()
     bot = Bot(token=tg_token)
@@ -79,6 +87,12 @@ def create_bot_server(tg_token: str, chat_id: str, ci_secret: str) -> FastAPI:
                 reply_markup=markup,
             )
             logger.info(f"Отчёт о CI отправлен: {project} | {branch} | {status}")
+
+            # Сохраняем последний деплой в main с успешным статусом
+            if branch == "main" and "✅" in status:
+                global _last_deploy_report
+                _last_deploy_report = text
+
         except Exception as e:
             logger.error(f"Ошибка при отправке сообщения в Telegram: {e}")
             raise HTTPException(status_code=500, detail="Ошибка при отправке сообщения")

--- a/bot.py
+++ b/bot.py
@@ -52,7 +52,7 @@ httpx_logger.setLevel(logging.WARNING)
 # Импорт модулей
 try:
     from chat import gpt, reset_context
-    from CI_report import create_bot_server
+    from CI_report import create_bot_server, get_last_deploy_report
     from system_report import main as report
 except ImportError as e:
     logger.error(f"Ошибка импорта модулей: {e}")
@@ -130,6 +130,22 @@ class Main:
             )
             logger.info("Получено сообщение вне активного режима.")
 
+    async def lastdeploy(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        report = get_last_deploy_report()
+        if report:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text=report,
+                parse_mode="HTML",
+            )
+        else:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text="Нет данных о последнем деплое в main.",
+            )
+
 
 # Запуск FastAPI и Telegram
 async def run_fastapi():
@@ -154,6 +170,7 @@ def main_func():
     application.add_handler(CommandHandler("chat", main_handler.lana))
     application.add_handler(CommandHandler("status", main_handler.status))
     application.add_handler(CommandHandler("reset", main_handler.reset))
+    application.add_handler(CommandHandler("lastdeploy", main_handler.lastdeploy))
     application.add_handler(
         MessageHandler(filters.TEXT & (~filters.COMMAND), main_handler.echo_message)
     )


### PR DESCRIPTION
Implement functionality to send the last deploy report via Telegram, allowing users to access deployment status directly through a command. Store the last successful deploy report for retrieval.